### PR TITLE
fix continue train iter count error

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,14 +24,17 @@ dataloader = data.create_dataloader(opt)
 trainer = Pix2PixTrainer(opt)
 
 # create tool for counting iterations
-iter_counter = IterationCounter(opt, len(dataloader))
+iter_counter = IterationCounter(opt, len(dataloader) * opt.batchSize)
 
 # create tool for visualization
 visualizer = Visualizer(opt)
 
 for epoch in iter_counter.training_epochs():
     iter_counter.record_epoch_start(epoch)
-    for i, data_i in enumerate(dataloader, start=iter_counter.epoch_iter):
+    for i, data_i in enumerate(dataloader):
+        if i < iter_counter.epoch_iter // opt.batchSize:
+            continue
+
         iter_counter.record_one_iteration()
 
         # Training

--- a/util/iter_counter.py
+++ b/util/iter_counter.py
@@ -35,7 +35,6 @@ class IterationCounter():
 
     def record_epoch_start(self, epoch):
         self.epoch_start_time = time.time()
-        self.epoch_iter = 0
         self.last_iter_time = time.time()
         self.current_epoch = epoch
 


### PR DESCRIPTION
* `IterationCounter` should receive dataset size, not dataloader size (`dataset_size // batchsize`).
* when continue training, should skip the leading `epoch_iter // batchsize` batches.