### PR TITLE
Replace scipy.misc.toimage to fix NVlabs#98

### DIFF
--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -8,7 +8,7 @@ import ntpath
 import time
 from . import util
 from . import html
-import scipy.misc
+from PIL import Image
 try:
     from StringIO import StringIO  # Python 2.7
 except ImportError:
@@ -54,7 +54,7 @@ class Visualizer():
                     s = BytesIO()
                 if len(image_numpy.shape) >= 4:
                     image_numpy = image_numpy[0]
-                scipy.misc.toimage(image_numpy).save(s, format="jpeg")
+                Image.fromarray(image_numpy).save(s, format="jpeg")
                 # Create an Image object
                 img_sum = self.tf.Summary.Image(encoded_image_string=s.getvalue(), height=image_numpy.shape[0], width=image_numpy.shape[1])
                 # Create a Summary value


### PR DESCRIPTION
scipy.misc.toimage has been removed from SciPy 1.3.0 : https://docs.scipy.org/doc/scipy-1.3.0/reference/release.1.3.0.html#scipy-interpolate-changes
PIL.Image.fromarray was recommended as an alternative : https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.misc.toimage.html#scipy.misc.toimage

This fixes NVlabs#98