### PR TITLE
update as_grey argument of skimage.io.imread to as_gray

### DIFF
--- a/datasets/coco_generate_instance_map.py
+++ b/datasets/coco_generate_instance_map.py
@@ -38,7 +38,7 @@ for ix, id in enumerate(imgIds):
     filename = img_dict["file_name"].replace("jpg", "png")
     label_name = os.path.join(opt.input_label_dir, filename)
     inst_name = os.path.join(opt.output_instance_dir, filename)
-    img = io.imread(label_name, as_grey=True)
+    img = io.imread(label_name, as_gray=True)
 
     annIds = coco.getAnnIds(imgIds=id, catIds=[], iscrowd=None)
     anns = coco.loadAnns(annIds)


### PR DESCRIPTION
## Problem
```
TypeError: _open() got an unexpected keyword argument 'as_grey'
```

## Solution

sklearn does support ```as_gray``` argument, not ```as_grey```.

## Reference

https://github.com/scikit-image/scikit-image/blob/v0.18.0/skimage/io/_io.py#L14-L63

