### PR TITLE
upadte some code to normalize data to prevent array subscripts from c…

### DIFF
--- a/models/pix2pix_model.py
+++ b/models/pix2pix_model.py
@@ -119,7 +119,10 @@ class Pix2PixModel(torch.nn.Module):
         nc = self.opt.label_nc + 1 if self.opt.contain_dontcare_label \
             else self.opt.label_nc
         input_label = self.FloatTensor(bs, nc, h, w).zero_()
-        input_semantics = input_label.scatter_(1, label_map, 1.0)
+        '''
+            Normalize data to prevent array subscripts from crossing bounds
+        '''
+        input_semantics = input_label.scatter_(1, label_map//255*nc, 1.0)
 
         # concatenate instance map if it exists
         if not self.opt.no_instance:


### PR DESCRIPTION
## the cause of a bug

We're using a function called 'scatter_()' here 
`self [i] [index [i] [j] [k] ] [k] = src [i] [j] [k]  # if dim == 1`

But we know that the value of the pixels in an image is in[0,255)

so `index[i][j][k]` might be 255

if  `label_nc`  is 13 ，255 is clearly greater than 13 ，

and that's what's going to cause the subscript to go out of bounds

![image](https://user-images.githubusercontent.com/75230173/158938751-e0a38dc1-7192-4165-8168-934bf1bd16af.png)


## solution

We can standardize the data in this way

`label_map  =  label_map //255 * nc`

So that each number in label_map is less than `label_nc`
